### PR TITLE
Fix typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ Built with:
 - Android Bluetooth LE APIs
 
 - CLAUDE.ai / Gemini (better!) / chatgpt etc.
-- I found it best to reset the chat for each incremental code change. Remove uneeded debugging and functions as soon as possible. Keep code size small. Keep chat purpose small and contained, with clear end goal (add feature X), start a new chat once finished, pasting updated code in. 
+- I found it best to reset the chat for each incremental code change. Remove unneeded debugging and functions as soon as possible. Keep code size small. Keep chat purpose small and contained, with clear end goal (add feature X), start a new chat once finished, pasting updated code in. 
 
 ## License
 


### PR DESCRIPTION
## Summary
- fix typo in README: "uneeded" -> "unneeded"

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a9ede14b888328ae3acdfe2e1cc8d2